### PR TITLE
fix: rename the option alias `-m` to `-t`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ ghatm set
 
 then `ghatm` checks GitHub Actions workflows `^\.github/workflows/.*\.ya?ml$` and sets `timeout-minutes: 30` to jobs which don't have `timeout-minutes`.
 Jobs which have `timeout-minutes` aren't changed.
-You can specify the value of `timeout-minutes` with `-m` option.
+You can specify the value of `timeout-minutes` with `-t` option.
 
 ```sh
-ghatm set -m 60
+ghatm set -t 60
 ```
 
 You can specify workflow files by positional arguments.

--- a/pkg/cli/set.go
+++ b/pkg/cli/set.go
@@ -25,7 +25,7 @@ $ ghatm set
 		Flags: []cli.Flag{
 			&cli.IntFlag{
 				Name:    "timeout-minutes",
-				Aliases: []string{"m"},
+				Aliases: []string{"t"},
 				Usage:   "The value of timeout-minutes",
 				Value:   30, //nolint:mnd
 			},


### PR DESCRIPTION
I think the alias of `-timeout-minutes` should be `-t` rather than `-m`.

BREAKING CHNAGE: The option `-m` doesn't work anymore