### PR TITLE
`timeout-minutes` can be an expression

### DIFF
--- a/pkg/edit/edit.go
+++ b/pkg/edit/edit.go
@@ -35,27 +35,9 @@ func ListJobsWithoutTimeout(jobs map[string]*Job) map[string]struct{} {
 }
 
 func hasTimeout(job *Job) bool {
-	if job.Uses != "" {
+	if job.TimeoutMinutes != nil || job.Uses != "" {
 		return true
 	}
-
-	switch v := job.TimeoutMinutes.(type) {
-	case int:
-		if v != 0 {
-			return true
-		}
-	// An expression like "${{ inputs.timeout }}" is considered as having a timeout
-	case string:
-		if strings.Contains(v, "${{") {
-			return true
-		}
-	case nil:
-		// TimeoutMinutes is not set
-	default:
-		// Any other non-nil value is considered as having a timeout for future compatibility
-		return true
-	}
-
 	for _, step := range job.Steps {
 		if step.TimeoutMinutes == 0 {
 			return false

--- a/pkg/edit/edit.go
+++ b/pkg/edit/edit.go
@@ -35,7 +35,7 @@ func ListJobsWithoutTimeout(jobs map[string]*Job) map[string]struct{} {
 }
 
 func hasTimeout(job *Job) bool {
-	if job.TimeoutMinutes != 0 || job.Uses != "" {
+	if job.TimeoutMinutes.HasValue() || job.Uses != "" {
 		return true
 	}
 	for _, step := range job.Steps {

--- a/pkg/edit/edit_internal_test.go
+++ b/pkg/edit/edit_internal_test.go
@@ -28,9 +28,7 @@ func TestEdit(t *testing.T) { //nolint:gocognit,cyclop,funlen
 						Uses: "suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@813a6d08c08cfd7a08618a89a59bfe78e573597c # v1.0.1",
 					},
 					"foo": {
-						TimeoutMinutes: TimeoutMinutes{
-							IntValue: 5,
-						},
+						TimeoutMinutes: 5,
 						Steps: []*Step{
 							{},
 						},
@@ -64,9 +62,7 @@ func TestEdit(t *testing.T) { //nolint:gocognit,cyclop,funlen
 						Uses: "suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@813a6d08c08cfd7a08618a89a59bfe78e573597c # v1.0.1",
 					},
 					"foo": {
-						TimeoutMinutes: TimeoutMinutes{
-							IntValue: 5,
-						},
+						TimeoutMinutes: 5,
 						Steps: []*Step{
 							{},
 						},
@@ -89,16 +85,13 @@ func TestEdit(t *testing.T) { //nolint:gocognit,cyclop,funlen
 			wf: &Workflow{
 				Jobs: map[string]*Job{
 					"with-timeout": {
-						TimeoutMinutes: TimeoutMinutes{
-							StringValue:  "${{ inputs.timeout }}",
-							IsExpression: true,
-						}, // This should be detected as having a timeout via inputs
+						TimeoutMinutes: "${{ inputs.timeout }}", // This should be detected as having a timeout via inputs
 						Steps: []*Step{
 							{},
 						},
 					},
 					"without-timeout": {
-						TimeoutMinutes: TimeoutMinutes{}, // This should get a default timeout added
+						TimeoutMinutes: nil, // This should get a default timeout added
 						Steps: []*Step{
 							{},
 						},

--- a/pkg/edit/edit_internal_test.go
+++ b/pkg/edit/edit_internal_test.go
@@ -28,7 +28,9 @@ func TestEdit(t *testing.T) { //nolint:gocognit,cyclop,funlen
 						Uses: "suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@813a6d08c08cfd7a08618a89a59bfe78e573597c # v1.0.1",
 					},
 					"foo": {
-						TimeoutMinutes: 5,
+						TimeoutMinutes: TimeoutMinutes{
+							IntValue: 5,
+						},
 						Steps: []*Step{
 							{},
 						},
@@ -62,7 +64,9 @@ func TestEdit(t *testing.T) { //nolint:gocognit,cyclop,funlen
 						Uses: "suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@813a6d08c08cfd7a08618a89a59bfe78e573597c # v1.0.1",
 					},
 					"foo": {
-						TimeoutMinutes: 5,
+						TimeoutMinutes: TimeoutMinutes{
+							IntValue: 5,
+						},
 						Steps: []*Step{
 							{},
 						},
@@ -72,6 +76,31 @@ func TestEdit(t *testing.T) { //nolint:gocognit,cyclop,funlen
 							{
 								TimeoutMinutes: 5,
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// The tool should recognize ${{ inputs.timeout }} in with-timeout job and add timeout to without-timeout job
+			name:    "reusable_workflow_timeout",
+			content: "reusable_workflow_timeout.yaml",
+			result:  "reusable_workflow_timeout_result.yaml",
+			wf: &Workflow{
+				Jobs: map[string]*Job{
+					"with-timeout": {
+						TimeoutMinutes: TimeoutMinutes{
+							StringValue:  "${{ inputs.timeout }}",
+							IsExpression: true,
+						}, // This should be detected as having a timeout via inputs
+						Steps: []*Step{
+							{},
+						},
+					},
+					"without-timeout": {
+						TimeoutMinutes: TimeoutMinutes{}, // This should get a default timeout added
+						Steps: []*Step{
+							{},
 						},
 					},
 				},

--- a/pkg/edit/testdata/reusable_workflow_timeout.yaml
+++ b/pkg/edit/testdata/reusable_workflow_timeout.yaml
@@ -1,0 +1,24 @@
+name: Test for reusable workflow timeout
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        required: false
+        type: number
+        default: 2
+jobs:
+  with-timeout:
+    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait
+        shell: bash
+        run: |
+          for i in {1..180}; do
+            echo "${i}"
+            sleep 1
+          done
+  without-timeout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3

--- a/pkg/edit/testdata/reusable_workflow_timeout_result.yaml
+++ b/pkg/edit/testdata/reusable_workflow_timeout_result.yaml
@@ -1,0 +1,25 @@
+name: Test for reusable workflow timeout
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        required: false
+        type: number
+        default: 2
+jobs:
+  with-timeout:
+    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait
+        shell: bash
+        run: |
+          for i in {1..180}; do
+            echo "${i}"
+            sleep 1
+          done
+  without-timeout:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3

--- a/pkg/edit/workflow.go
+++ b/pkg/edit/workflow.go
@@ -14,49 +14,11 @@ type Workflow struct {
 	Jobs map[string]*Job
 }
 
-// TimeoutMinutes is a custom type that can be either an integer or an expression string
-type TimeoutMinutes struct {
-	IntValue     int
-	StringValue  string
-	IsExpression bool
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface
-func (t *TimeoutMinutes) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Try to unmarshal as int
-	var intValue int
-	if err := unmarshal(&intValue); err == nil {
-		t.IntValue = intValue
-		t.IsExpression = false
-		return nil
-	}
-
-	// Try to unmarshal as string
-	var strValue string
-	if err := unmarshal(&strValue); err != nil {
-		return err
-	}
-
-	// Check if the string is an expression
-	if !strings.Contains(strValue, "${{") {
-		return fmt.Errorf("timeout-minutes must be either an integer or an expression, got: %s", strValue)
-	}
-
-	t.StringValue = strValue
-	t.IsExpression = true
-	return nil
-}
-
-// HasValue returns true if the timeout has a value (either int or expression)
-func (t *TimeoutMinutes) HasValue() bool {
-	return t.IntValue != 0 || t.IsExpression
-}
-
 type Job struct {
 	Name           string
 	Steps          []*Step
 	Uses           string
-	TimeoutMinutes TimeoutMinutes `yaml:"timeout-minutes"`
+	TimeoutMinutes any `yaml:"timeout-minutes"`
 	Strategy       any
 }
 

--- a/pkg/edit/workflow.go
+++ b/pkg/edit/workflow.go
@@ -14,11 +14,49 @@ type Workflow struct {
 	Jobs map[string]*Job
 }
 
+// TimeoutMinutes is a custom type that can be either an integer or an expression string
+type TimeoutMinutes struct {
+	IntValue     int
+	StringValue  string
+	IsExpression bool
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (t *TimeoutMinutes) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Try to unmarshal as int
+	var intValue int
+	if err := unmarshal(&intValue); err == nil {
+		t.IntValue = intValue
+		t.IsExpression = false
+		return nil
+	}
+
+	// Try to unmarshal as string
+	var strValue string
+	if err := unmarshal(&strValue); err != nil {
+		return err
+	}
+
+	// Check if the string is an expression
+	if !strings.Contains(strValue, "${{") {
+		return fmt.Errorf("timeout-minutes must be either an integer or an expression, got: %s", strValue)
+	}
+
+	t.StringValue = strValue
+	t.IsExpression = true
+	return nil
+}
+
+// HasValue returns true if the timeout has a value (either int or expression)
+func (t *TimeoutMinutes) HasValue() bool {
+	return t.IntValue != 0 || t.IsExpression
+}
+
 type Job struct {
 	Name           string
 	Steps          []*Step
 	Uses           string
-	TimeoutMinutes int `yaml:"timeout-minutes"`
+	TimeoutMinutes TimeoutMinutes `yaml:"timeout-minutes"`
 	Strategy       any
 }
 


### PR DESCRIPTION
Thank you for this amazing tool. At Finatext, we're trying ghatm along with https://github.com/Finatext/orgu to set our default `timeout-minutes` across all our organization's repositories. While running jobs in production, we noticed this corner case and would like to contribute an implementation to address it.

## Problem
When using reusable workflows with `timeout-minutes` that accept input parameters (e.g., `timeout-minutes: ${{ inputs.timeout }}`), ghatm would fail with an unmarshal error:

```
unmarshal a workflow file: yaml: unmarshal errors like:
  line 36: cannot unmarshal !!str `${{ inp...` into int
```

This occurred because the `TimeoutMinutes` field was defined as an integer type, but GitHub Actions allows expressions like `${{ inputs.timeout }}` to be used, especially in reusable workflows.

## Approaches Considered

### Approach 1: Modify AST parsing logic

Initially, we considered modifying the AST parsing logic in `ast.go` to detect when a job has a `timeout-minutes` field with an expression and exclude it from the list of jobs without timeout.

**Pros:**
- Minimal changes to existing data structures
- No need to modify YAML unmarshaling logic

**Cons:**
- More complex code in the AST parsing layer
- Less type safety
- Harder to extend for future enhancements
- Treats the symptom rather than the root cause

### Approach 2: Use interface{} type for TimeoutMinutes

We also considered changing the `TimeoutMinutes` field to an `interface{}` type that could hold either an int or a string.

**Pros:**
- Relatively simple implementation
- Flexible for different value types

**Cons:**
- Type assertions required when using the value
- Less type safety
- Potential for runtime errors

### Approach 3: Custom TimeoutMinutes type (chosen solution)

We implemented a custom `TimeoutMinutes` type with proper YAML unmarshaling support.

**Pros:**
- Type-safe solution
- Clear separation between integer and expression values
- Explicit validation of expression syntax
- Better extensibility for future enhancements
- Cleaner code organization

**Cons:**
- Required more changes across the codebase
- Slightly more complex implementation

## Implementation

We chose Approach 3 because it provides the best balance of type safety, code clarity, and maintainability. The custom type approach properly models the domain concept (a timeout value that can be either an integer or an expression) and provides clear validation rules.

The implementation includes:
- A custom `TimeoutMinutes` type with fields for both integer values and expressions
- YAML unmarshaling logic that handles both types of values
- Validation to ensure string values are valid expressions
- Updated logic to recognize expressions as valid timeout values

This approach addresses the root cause of the issue rather than just treating the symptoms, making the code more robust for future enhancements.
