### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
       go-version-file: go.mod
       aqua_policy_allow: true
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,11 @@ permissions: {}
 jobs:
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: read
+      id-token: write
   status-check:
     runs-on: ubuntu-24.04
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -6,12 +6,17 @@ on:
       docker_is_changed:
         required: false
         type: boolean
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -20,6 +25,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   path-filter:
@@ -30,4 +34,8 @@ jobs:
   test:
     uses: ./.github/workflows/wc-test.yaml
     needs: path-filter
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard into the CI workflows to guard Go module downloads.

## Changes

- `.github/workflows/release.yaml`
  - Add a `secrets:` block to the `release` job passing `TAKUMI_GUARD_BOT_ID` to the called `go-release-workflow` (ref already pinned at `v8.1.0`).

- `.github/workflows/wc-test.yaml` (reusable `workflow_call` running Go commands directly)
  - Declare `secrets.TAKUMI_GUARD_BOT_ID` as `required: true`.
  - Insert the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` step (with `bot-id`) right after `actions/setup-go` and before `aqua-installer` / the module-downloading steps (`golangci-lint run`, `go test`, `go run`).
  - Add `id-token: write` (and `contents: read`) to the `test` job's previously empty `permissions`.

- `.github/workflows/workflow_call_test.yaml` (reusable `workflow_call` calling `wc-test.yaml`)
  - Declare `secrets.TAKUMI_GUARD_BOT_ID` as `required: true`.
  - Pass `TAKUMI_GUARD_BOT_ID` to the `test` job and add `id-token: write` (and `contents: read`) to its permissions.

- `.github/workflows/test.yaml` (entrypoint, `pull_request`, calling `workflow_call_test.yaml`)
  - Pass `TAKUMI_GUARD_BOT_ID` to the `test` job and add `id-token: write` to its permissions.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)