### PR TITLE
fix: use promoted fields in struct literals

### DIFF
--- a/pkg/github/workflow_job.go
+++ b/pkg/github/workflow_job.go
@@ -28,10 +28,8 @@ type WorkflowJob struct {
 
 func (c *Client) ListWorkflowJobs(ctx context.Context, logger *slog.Logger, owner, repo string, runID int64, opts *ListWorkflowJobsOptions) ([]*WorkflowJob, *github.Response, error) {
 	o := &github.ListWorkflowJobsOptions{
-		ListOptions: github.ListOptions{
-			PerPage: 100, //nolint:mnd
-			Page:    opts.Page,
-		},
+		PerPage: 100, //nolint:mnd
+		Page:    opts.Page,
 	}
 	jobs, resp, err := c.actions.ListWorkflowJobs(ctx, owner, repo, runID, o)
 	if err != nil {

--- a/pkg/github/workflow_run.go
+++ b/pkg/github/workflow_run.go
@@ -19,11 +19,9 @@ type WorkflowRun struct {
 
 func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo, workflowFileName string, opts *ListWorkflowRunsOptions) ([]*WorkflowRun, *github.Response, error) {
 	o := &github.ListWorkflowRunsOptions{
-		ListOptions: github.ListOptions{
-			PerPage: 100, //nolint:mnd
-			Page:    opts.Page,
-		},
-		Status: opts.Status,
+		PerPage: 100, //nolint:mnd
+		Page:    opts.Page,
+		Status:  opts.Status,
 	}
 	runs, resp, err := c.actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFileName, o)
 	if err != nil {


### PR DESCRIPTION
Fixes the CI failure on the Renovate PR this branches from, so that the Go 1.27 module directive can be merged.

Raising the `go` directive to 1.27.0 turns on `modernize`'s `embedlit` check, which reports struct literals that name an embedded field explicitly:

```
embedlit: embedded field type can be removed from struct literal (modernize)
```

Go 1.27 lets a composite literal set a promoted field directly, so the wrapper is no longer needed:

```diff
 opts := &ListWorkflowJobsOptions{
-    ListOptions: ListOptions{
-        PerPage: maxPerPage,
-    },
+    PerPage: maxPerPage,
 }
```

Applied with `golangci-lint run --fix`, not by hand. No behaviour change — the same fields are set on the same embedded struct.

Verified locally with golangci-lint v2.13.0 under Go 1.27: `go build ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all pass.

Base is the Renovate branch, so merging this puts the fix on it.
